### PR TITLE
Add *.dSYM to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
 *.a
+*.dSYM
 repl
 ebisp_test


### PR DESCRIPTION
When using clang under macOS, the folder `ebisp_test.dSYM` and `repl.dSYM` are generated.
These folders are not worth being version-controlled.