### PR TITLE
CC variable, Makefile target 'clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,28 @@
 CS=src/builtins.c src/expr.c src/gc.c src/interpreter.c src/parser.c src/scope.c src/std.c src/tokenizer.c src/str.c
 OBJS=builtins.o expr.o gc.o interpreter.o parser.o scope.o std.o tokenizer.o str.o
 CFLAGS=-Wall -Werror -ggdb
+CC=gcc
 
 .PHONY: all
 all: libebisp.a repl
 
 $(OBJS): $(CS)
-	gcc $(CFLAGS) -c $(CS)
+	$(CC) $(CFLAGS) -c $(CS)
 
 libebisp.a: $(OBJS)
 	ar -crs libebisp.a $(OBJS)
 
 repl: libebisp.a src/repl.c src/repl_runtime.c
-	gcc $(CFLAGS) -o repl src/repl.c src/repl_runtime.c -L. -lebisp
+	$(CC) $(CFLAGS) -o repl src/repl.c src/repl_runtime.c -L. -lebisp
 
 .PHONY: test
 test: ebisp_test
 	./ebisp_test
 
 ebisp_test: libebisp.a test/main.c
-	gcc $(CFLAGS) -Isrc/ -o ebisp_test test/main.c -L. -lebisp
+	$(CC) $(CFLAGS) -Isrc/ -o ebisp_test test/main.c -L. -lebisp
+
+.PHONY: clean
+clean:
+	rm -fr *.dSYM libebisp.a repl ebisp_test
+

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,3 @@ test: ebisp_test
 ebisp_test: libebisp.a test/main.c
 	$(CC) $(CFLAGS) -Isrc/ -o ebisp_test test/main.c -L. -lebisp
 
-.PHONY: clean
-clean:
-	rm -fr *.dSYM libebisp.a repl ebisp_test
-


### PR DESCRIPTION
In order to support clang, the CC variable can be defined, defaulting to `gcc`.
That way, a gcc-compatible compiler can be used.

Also, there was no `clean` target defined in Makefile.
This PR introduces `clean`.
